### PR TITLE
feat: add filter pedidos

### DIFF
--- a/go/handlers/PedidosHandler.go
+++ b/go/handlers/PedidosHandler.go
@@ -150,3 +150,19 @@ func (ph *PedidosHandler) ActualizarPedidoAceptado(c *gin.Context) {
 
 	c.JSON(http.StatusOK, gin.H{"mensaje": "Pedido actualizado a aceptado exitosamente"})
 }
+
+func (h *PedidosHandler) ObtenerPedidosFiltrados(c *gin.Context) {
+	var filtro utils.FiltroPedido
+	if err := c.ShouldBindJSON(&filtro); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Datos de filtro inválidos"})
+		return
+	}
+
+	pedidos, err := h.pedidosService.ObtenerPedidosFiltrados(&filtro)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error al obtener pedidos"})
+		return
+	}
+
+	c.JSON(http.StatusOK, pedidos)
+}

--- a/go/main.go
+++ b/go/main.go
@@ -61,7 +61,7 @@ func mappingRoutes() {
 	router.GET("/pedidos", pedidosHandler.ObtenerPedidos)
 	router.GET("/pedidos/aceptados", pedidosHandler.ObtenerPedidosAceptados)
 	//Se puede filtrar por código de envío, estado, rango de fecha de creación.
-	//router.PUT("/pedidos/:id", pedidosHandler.ActualizarPedido)
+	router.POST("/pedidos/filtrado", pedidosHandler.ObtenerPedidosFiltrados)
 	router.PUT("/pedidos/cancelar/:id", pedidosHandler.EliminarPedido)
 	//Lista pedidos pendientes
 	router.GET("/pedidos/pendientes", pedidosHandler.ObtenerPedidosPendientes)

--- a/go/repositories/PedidosRepository.go
+++ b/go/repositories/PedidosRepository.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Choolito/ucse-prog2-2023-integrador-LosPlaplas/go/model"
 	"github.com/Choolito/ucse-prog2-2023-integrador-LosPlaplas/go/utils"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
@@ -20,6 +21,7 @@ type PedidosRepositoryInterface interface {
 	ObtenerPedidosPendientes() ([]*model.Pedidos, error)
 	ObtenerPedidosAceptados() ([]*model.Pedidos, error)
 	ActualizarPedidoAceptado(id string) (*mongo.UpdateResult, error)
+	ObtenerPedidosFiltrados(filtro *utils.FiltroPedido) ([]*model.Pedidos, error)
 
 	//envio
 	ObtenerPedidoPorID(id string) (*model.Pedidos, error)
@@ -228,4 +230,59 @@ func (pr *PedidosRepository) ActualizarPedidoEnviado(id string) (*mongo.UpdateRe
 	resultado, err := collection.UpdateOne(context.Background(), filtro, update)
 
 	return resultado, err
+}
+
+func (r *PedidosRepository) ObtenerPedidosFiltrados(filtro *utils.FiltroPedido) ([]*model.Pedidos, error) {
+	collectionEnvios := r.db.GetClient().Database("LosPlaplas").Collection("envios")
+	collectionPedidos := r.db.GetClient().Database("LosPlaplas").Collection("pedidos")
+
+	filterMongo := bson.M{}
+
+	// Filtrar por código de envío
+	if filtro.IdEnvio != "" {
+		var envio struct {
+			Pedidos []primitive.ObjectID `bson:"pedidos"`
+		}
+		idEnvio, err := utils.GetObjectIDFromStringIDErr(filtro.IdEnvio)
+		if err != nil {
+			return nil, err
+		}
+
+		err = collectionEnvios.FindOne(context.TODO(), bson.M{"_id": idEnvio}).Decode(&envio)
+		if err != nil {
+			if err == mongo.ErrNoDocuments {
+				return []*model.Pedidos{}, nil
+			}
+			return nil, err
+		}
+
+		// Filtrar los pedidos por los IDs obtenidos del Envío
+		filterMongo["_id"] = bson.M{"$in": envio.Pedidos}
+	}
+
+	// Filtrar por estado del pedido
+	if filtro.Estado != "" {
+		filterMongo["estadoPedido"] = filtro.Estado
+	}
+
+	// Filtrar por rango de fechas
+	if !filtro.FechaCreacionComienzo.IsZero() && !filtro.FechaCreacionFin.IsZero() {
+		filterMongo["fechaCreacion"] = bson.M{
+			"$gte": filtro.FechaCreacionComienzo,
+			"$lte": filtro.FechaCreacionFin,
+		}
+	}
+
+	cursor, err := collectionPedidos.Find(context.TODO(), filterMongo)
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(context.TODO())
+
+	var pedidos []*model.Pedidos
+	if err = cursor.All(context.TODO(), &pedidos); err != nil {
+		return nil, err
+	}
+
+	return pedidos, nil
 }

--- a/go/services/PedidosService.go
+++ b/go/services/PedidosService.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/Choolito/ucse-prog2-2023-integrador-LosPlaplas/go/utils"
+
 	"github.com/Choolito/ucse-prog2-2023-integrador-LosPlaplas/go/dto"
 	"github.com/Choolito/ucse-prog2-2023-integrador-LosPlaplas/go/repositories"
 )
@@ -16,6 +18,7 @@ type PedidosInterface interface {
 	ObtenerPedidosPendientes() ([]*dto.Pedidos, error)
 	ObtenerPedidosAceptados() ([]*dto.Pedidos, error)
 	ActualizarPedidoAceptado(id string) error
+	ObtenerPedidosFiltrados(filtro *utils.FiltroPedido) ([]*dto.Pedidos, error)
 }
 
 type PedidosService struct {
@@ -127,4 +130,18 @@ func (ps *PedidosService) ActualizarPedidoAceptado(id string) error {
 		return fmt.Errorf("no se pudo actualizar el pedido con el id: %s", id)
 	}
 	return nil
+}
+
+func (s *PedidosService) ObtenerPedidosFiltrados(filtro *utils.FiltroPedido) ([]*dto.Pedidos, error) {
+	pedidosModel, err := s.pedidosRepository.ObtenerPedidosFiltrados(filtro)
+	if err != nil {
+		return nil, err
+	}
+
+	var pedidosDTO []*dto.Pedidos
+	for _, pedido := range pedidosModel {
+		pedidosDTO = append(pedidosDTO, dto.NewPedidos(*pedido))
+	}
+
+	return pedidosDTO, nil
 }

--- a/go/utils/FiltroPedido.go
+++ b/go/utils/FiltroPedido.go
@@ -5,9 +5,7 @@ import (
 )
 
 type FiltroPedido struct {
-	IdPedidos             []string
 	IdEnvio               string
-	CodigoProducto        string
 	Estado                string
 	FechaCreacionComienzo time.Time
 	FechaCreacionFin      time.Time

--- a/go/utils/ids.go
+++ b/go/utils/ids.go
@@ -7,6 +7,11 @@ func GetObjectIDFromStringID(id string) primitive.ObjectID {
 	return objID
 }
 
+func GetObjectIDFromStringIDErr(id string) (primitive.ObjectID, error) {
+	objID, err := primitive.ObjectIDFromHex(id)
+	return objID, err
+}
+
 func GetStringIDFromObjectID(id primitive.ObjectID) string {
 	return id.Hex()
 }

--- a/web/envios/index_envio.html
+++ b/web/envios/index_envio.html
@@ -70,6 +70,7 @@
         <table id="elementosTable">
             <thead>
                 <tr>
+                    <th>Codigo Envio</th>
                     <th>Patente</th>
                     <th>Ciudad Actual</th>
                     <th>Ciudad Destino</th>

--- a/web/envios/scripts.js
+++ b/web/envios/scripts.js
@@ -145,6 +145,7 @@ function renderizarTablaEnvios(response) {
       const kilometrosRecorridos = calcularKilometrosRecorridos(elemento.Paradas)
 
       row.innerHTML = `
+        <td>${elemento.ID}</td>
         <td>${camionInfo ? camionInfo.patente : "No encontrado"}</td>
         <td>${ciudadActual}</td>
         <td>${ciudadDestino}</td>


### PR DESCRIPTION
Se puede filtrar por estos campos
{
    "idEnvio": "",
    "estado": "",
    "fechaCreacionComienzo":null,
    "fechaCreacionFin": null
}

las fechas poseen el mismo formato que el de envios